### PR TITLE
upgrade: tailwind-railsのアップデート

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ group :test do
   gem "simplecov", require: false
 end
 
-gem "tailwindcss-rails", "~> 3.3.1"
+gem "tailwindcss-rails", "~> 3.3.2"
 gem "tailwindcss-ruby", "3.4.17"
 
 gem "devise"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,7 +376,7 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.5)
-    tailwindcss-rails (3.3.1)
+    tailwindcss-rails (3.3.2)
       railties (>= 7.0.0)
       tailwindcss-ruby (~> 3.0)
     tailwindcss-ruby (3.4.17-aarch64-linux)
@@ -454,7 +454,7 @@ DEPENDENCIES
   simplecov
   sprockets-rails
   stimulus-rails
-  tailwindcss-rails (~> 3.3.1)
+  tailwindcss-rails (~> 3.3.2)
   tailwindcss-ruby (= 3.4.17)
   turbo-rails
   tzinfo-data


### PR DESCRIPTION
3.31→3.3.2のアップグレードでbin/dev実行時の下記の表示を消す。
```
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```
https://github.com/flavorjones/tailwindcss-ruby/issues/76