### PR TITLE
Post form UI change

### DIFF
--- a/app/controllers/techniques/youtube_controller.rb
+++ b/app/controllers/techniques/youtube_controller.rb
@@ -20,9 +20,11 @@ class Techniques::YoutubeController < ApplicationController
   def show
     @technique = Technique.find(params[:id])
 
+    # youtubeAPIを引っ張ってくる
     youtube_service = YoutubeService.new
     @movie_title = youtube_service.get_movie_title(@technique.only_id_from_youtube_url)
 
+    # おすすめ動画のためにIDをランダムで引っ張ってくる
     recommend_id = Technique.where(source_type: "youtube").where.not(id: @technique.id).pluck(:id).sample(5)
     @recommend_techniques = Technique.where(id: recommend_id)
   end

--- a/app/controllers/youtube_api_controller.rb
+++ b/app/controllers/youtube_api_controller.rb
@@ -1,10 +1,9 @@
 class YoutubeApiController < ApplicationController
-
   def title
     video_id = params[:video_id]
 
     if video_id.blank?
-      return render json: { error: 'ビデオIDが必要です' }, status: :bad_request
+      return render json: { error: "ビデオIDが必要です" }, status: :bad_request
     end
 
     begin
@@ -13,7 +12,7 @@ class YoutubeApiController < ApplicationController
       render json: { title: movie_title }
     rescue => e
       Rails.logger.error "YouTubeAPIのエラー： #{ e.message }"
-      render json: { error: 'ビデオタイトルの取得に失敗しました' }, status: :internal_server_error
+      render json: { error: "ビデオタイトルの取得に失敗しました" }, status: :internal_server_error
     end
   end
 end

--- a/app/controllers/youtube_api_controller.rb
+++ b/app/controllers/youtube_api_controller.rb
@@ -1,0 +1,19 @@
+class YoutubeApiController < ApplicationController
+
+  def title
+    video_id = params[:video_id]
+
+    if video_id.blank?
+      return render json: { error: 'ビデオIDが必要です' }, status: :bad_request
+    end
+
+    begin
+      youtube_service = YoutubeService.new
+      movie_title = youtube_service.get_movie_title(video_id)
+      render json: { title: movie_title }
+    rescue => e
+      Rails.logger.error "YouTubeAPIのエラー： #{ e.message }"
+      render json: { error: 'ビデオタイトルの取得に失敗しました' }, status: :internal_server_error
+    end
+  end
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import YoutubePreviewController from "./youtube_preview_controller"
+application.register("youtube-preview", YoutubePreviewController)

--- a/app/javascript/controllers/youtube_preview_controller.js
+++ b/app/javascript/controllers/youtube_preview_controller.js
@@ -75,7 +75,7 @@ export default class extends Controller {
     if (videoId) {
       // デフォルトの表示（まだフォームにURLが入っていない時）
       this.previewOriginalTitleTarget.textContent = "元動画：タイトルを取得中・・・。"
-      this.#fetchVideoTitle(url)
+      this.#fetchVideoTitle(videoId)
     } else {
       this.previewOriginalTitleTarget.textContent = "元動画：（ここに動画タイトルが表示されます）"
     }
@@ -96,14 +96,19 @@ export default class extends Controller {
     }
   }
 
-  async #fetchVideoTitle(youtubeUrl) {
+  async #fetchVideoTitle(videoId) {
     try {
-      const response = await fetch(`http://googleusercontent.com/youtube.com/oembed?url=${encodeURIComponent(youtubeUrl)}&format=json`)
+      const response = await fetch(`/youtube/title?video_id=${videoId}`)
       if (!response.ok) {
         throw new Error('YouTube APIからの応答がありませんでした。')
       }
       const data = await response.json()
-      this.previewOriginalTitleTarget.textContent = `元動画：${data.title}`
+
+      if (data.title) {
+        this.previewOriginalTitleTarget.textContent = `元動画：${data.title}`
+      } else {
+        throw new Error('JSONにタイトルが含まれていません。')
+      }
     } catch (error) {
       console.error("動画タイトルの取得に失敗しました:", error)
       this.previewOriginalTitleTarget.textContent = "元動画：タイトルの取得に失敗しました"

--- a/app/javascript/controllers/youtube_preview_controller.js
+++ b/app/javascript/controllers/youtube_preview_controller.js
@@ -1,0 +1,53 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="youtube-preview"
+export default class extends Controller {
+
+  // HTMLの要素（ターゲット）をココで指定しておく
+  static targets = [ "sourceUrl", "timestamp", "preview"]
+
+  update() {
+    const url = this.sourceUrlTarget.value;
+    const timestamp = this.timestampTarget.value;
+
+    // urlから抜き出したIDを代入
+    const videoId = this.youtubeVideoId(url);
+
+    // 秒数に変えた時間を代入
+    const startSeconds = this.timestampToSeconds(timestamp);
+
+    if (videoId) {
+      const iframe = document.createElement('iframe');
+      iframe.setAttribute('src', `https://www.youtube.com/embed/${videoId}?start=${startSeconds}`);
+      iframe.setAttribute('frameborder', '0');
+      iframe.setAttribute('allow', 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture');
+      iframe.setAttribute('allowfullscreen', '');
+      iframe.className = 'w-full h-full rounded-lg';
+
+      this.previewTarget.innerHTML = '';
+      this.previewTarget.appendChild(iframe);
+
+    } else {
+      this.previewTarget.innerHTML = '<span class="text-gray-500">投稿前にこちらで動画が確認できます</span>';
+    }
+  }
+
+  // urlの抜き出しメソッド
+  youtubeVideoId(url) {
+    // この正規表現はサイトを参考。https://follmy.com/ruby-youtube-embeded/
+    const regex = /(?:https:\/\/www\.youtube\.com(?:\/embed\/|\/watch\?v=)|https:\/\/youtu\.be\/)([a-zA-Z0-9_-]{11})/;
+    const match = url.match(regex);
+    return match ? match[1] : null;
+  }
+
+  // 時間を秒数に変えるメソッド
+  timestampToSeconds(timestamp) {
+    if (!timestamp) return 0;
+    const parts = timestamp.split(':').map(Number).reverse();
+    let seconds = 0;
+    if (parts[0]) seconds += parts[0];
+    if (parts[1]) seconds += parts[1] * 60;
+    if (parts[2]) seconds += parts[2] * 3600;
+    return isNaN(seconds) ? 0 : seconds;
+  }
+}

--- a/app/views/techniques/youtube/new.html.erb
+++ b/app/views/techniques/youtube/new.html.erb
@@ -1,61 +1,133 @@
 <% content_for(:title, t(".title")) %>
 
 <%# 生成した際に指示が書いてあったコントローラーの読み込みをココに追記 %>
-<div class="flex min-h-full flex-col justify-center md:m-12" data-controller="youtube-preview">
+<div class="flex min-h-full flex-col lg:flex-row lg:m-6 justify-center md:m-12" data-controller="youtube-preview">
 
-  <div class="sm:mx-auto sm:w-full sm:max-w-sm">
-    <h2 class="mt-10 text-center text-2xl/9 font-bold tracking-tight text-gray-900">YouTubeテクニック登録</h2>
-  </div>
-
-  <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-md">
-
-    <%# プレビュー画面 %>
-    <div data-youtube-preview-target="preview" class="mb-4 aspect-video w-full rounded-lg bg-gray-200 flex items-center justify-center">
-      <span class="text-gray-500">投稿前にこちらで動画が確認できます</span>
+  <%# ======左側：入力フォーム====== %>
+  <div class="w-full lg:w-1/2 xl:w-1/3">
+    <div class="sm:mx-auto sm:w-full sm:max-w-sm">
+      <h2 class="mt-10 text-center text-2xl/9 font-bold tracking-tight text-gray-900">YouTubeテクニック登録</h2>
     </div>
 
-    <%= form_with model: @technique, url: techniques_youtube_index_path do |f| %>
+    <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-md">
 
-      <%= render 'shared/error_message', object: f.object %>
+      <%= form_with model: @technique, url: techniques_youtube_index_path do |f| %>
+
+        <%= render 'shared/error_message', object: f.object %>
         <%= f.hidden_field :source_type %>
 
-      <div class="field py-2 px-4">
-        <%= f.text_field :source_url,
-              autofocus: true,
-              autocomplete: "title",
-              class: "input input-md input-bordered w-full",
-              placeholder: "#{@technique.source_type.humanize}のURL",
-              data: {
-                youtube_preview_target: "sourceUrl",
-                action: "input->youtube-preview#update", # inputがあったら、updateメソッドに投げる
-              }
-        %>
+        <div class="field py-2 px-4">
+          <%= f.text_field :source_url,
+                autofocus: true,
+                autocomplete: "title",
+                class: "input input-md input-bordered w-full",
+                placeholder: "#{@technique.source_type.humanize}のURL",
+                data: {
+                  youtube_preview_target: "sourceUrl",
+                  action: "input->youtube-preview#update input->youtube-preview#updateOriginalTitle"# inputがあったら、updateメソッドに投げる
+                }
+          %>
+        </div>
+
+        <div class="field py-2 px-4">
+          <%= f.text_field :video_timestamp,
+                class: "input input-md input-bordered w-full",
+                placeholder: "再生開始地点(HH:MM:SS or MM:SS or SSの形で入力)",
+                data: {
+                  youtube_preview_target: "timestamp",
+                  action: "input->youtube-preview#update"
+                }
+          %>
+        </div>
+
+        <div class="field py-2 px-4">
+          <%= f.text_field :title,
+                autofocus: true,
+                autocomplete: "title",
+                class: "input input-md input-bordered w-full",
+                placeholder: "タイトル",
+                data: {
+                  youtube_preview_target: "titleInput",
+                  action: "input->youtube-preview#update"
+                }
+          %>
+        </div>
+
+        <div class="field py-2 px-4">
+          <%= f.text_field :category_names,
+                class: "input input-md input-bordered w-full",
+                placeholder: "カテゴリー名（コンマ（,）区切りで複数入力可能）",
+                data: {
+                  youtube_preview_target: "categoryInput",
+                  action: "input->youtube-preview#update"
+                }
+          %>
+        </div>
+
+        <div class="actions text-center py-4 px-4">
+          <%= f.submit "投稿する！", class: "btn btn-wide" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+
+
+  <%# ======右側：ブラウザのモックアップ====== %>
+  <div class="w-full lg:w-1/2 xl:w-2/3 mt-10 lg:mt-0">
+    <div class="mockup-browser border-base-300 border">
+      <div class="mockup-browser-toolbar">
+        <div class="input border-base-300 border">https://v-tactics.com</div>
       </div>
 
-      <div class="field py-2 px-4">
-        <%= f.text_field :video_timestamp,
-              autofocus: true,
-              autocomplete: "title",
-              class: "input input-md input-bordered w-full",
-              placeholder: "再生開始地点(HH:MM:SS or MM:SS or SSの形で入力)",
-              data: {
-                youtube_preview_target: "timestamp",
-                action: "input->youtube-preview#update",
-              }
-        %>
+      <%# モックアップの中身 %>
+
+      <div class="border-base-300 flex flex-col items-center justify-center border-t px-4 py-8 md:px-8">
+
+        <div data-youtube-preview-target="preview" class="w-4/5 aspect-video rounded-lg bg-gray-200 flex items-center justify-center">
+          <span class="text-gray-500">投稿前にこちらで動画が確認できます</span>
+        </div>
+
+        <div data-youtube-preview-target="previewTitle" class="mt-4 text-xl font-bold line-clamp-1">タイトル</div>
+        <div data-youtube-preview-target="previewOriginalTitle" class="mt-2 text-md line-clamp-1">元動画：（ここに動画タイトルが表示されます）</div>
+
+        <div data-youtube-preview-target="previewCategories" class="mt-4 mb-4 flex flex-wrap gap-2">
+        </div>
+
+        <%# ボタン系 %>
+        <div class="mt-2 flex flex-wrap gap-3">
+
+          <div class="btn bg-red-500 text-white">YouTubeへ</div>
+
+          <div class="btn">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-twitter-x" viewBox="0 0 16 16">
+              <path d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865z"/>
+            </svg>
+            で共有する
+          </div>
+
+          <div class="btn">編集</div>
+          <div class="btn">削除</div>
+
+          <!-- マイフォルダに保存 ボタン -->
+          <div class="tooltip" data-tip="もうすぐ実装予定！">
+            <a href="#" class="btn btn-primary">マイフォルダに保存</a>
+          </div>
+
+          <%# お気に入りボタン %>
+          <div class="btn btn-soft btn-warning">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-star" viewBox="0 0 16 16">
+              <path d="M2.866 14.85c-.078.444.36.791.746.593l4.39-2.256 4.389 2.256c.386.198.824-.149.746-.592l-.83-4.73 3.522-3.356c.33-.314.16-.888-.282-.95l-4.898-.696L8.465.792a.513.513 0 0 0-.927 0L5.354 5.12l-4.898.696c-.441.062-.612.636-.283.95l3.523 3.356-.83 4.73zm4.905-2.767-3.686 1.894.694-3.957a.56.56 0 0 0-.163-.505L1.71 6.745l4.052-.576a.53.53 0 0 0 .393-.288L8 2.223l1.847 3.658a.53.53 0 0 0 .393.288l4.052.575-2.906 2.77a.56.56 0 0 0-.163.506l.694 3.957-3.686-1.894a.5.5 0 0 0-.461 0z"/>
+            </svg>
+            <span>お気に入り</span>
+          </div>
+
+        </div>
+
       </div>
 
-      <div class="field py-2 px-4">
-        <%= f.text_field :title, autofocus: true, autocomplete: "title", class: "input input-md input-bordered w-full", placeholder: "タイトル" %>
-      </div>
 
-      <div class="field py-2 px-4">
-        <%= f.text_field :category_names, autofocus: true, autocomplete: "title", class: "input input-md input-bordered w-full", placeholder: "カテゴリー名（コンマ（,）区切りで複数入力可能）" %>
-      </div>
 
-      <div class="actions text-center py-4 px-4">
-        <%= f.submit "投稿する！", class: "btn btn-wide" %>
-      </div>
-    <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/techniques/youtube/new.html.erb
+++ b/app/views/techniques/youtube/new.html.erb
@@ -1,23 +1,54 @@
 <% content_for(:title, t(".title")) %>
-<div class="flex min-h-full flex-col justify-center md:m-12">
+
+<%# 生成した際に指示が書いてあったコントローラーの読み込みをココに追記 %>
+<div class="flex min-h-full flex-col justify-center md:m-12" data-controller="youtube-preview">
+
   <div class="sm:mx-auto sm:w-full sm:max-w-sm">
     <h2 class="mt-10 text-center text-2xl/9 font-bold tracking-tight text-gray-900">YouTubeテクニック登録</h2>
   </div>
 
   <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-md">
 
+    <%# プレビュー画面 %>
+    <div data-youtube-preview-target="preview" class="mb-4 aspect-video w-full rounded-lg bg-gray-200 flex items-center justify-center">
+      <span class="text-gray-500">投稿前にこちらで動画が確認できます</span>
+    </div>
+
     <%= form_with model: @technique, url: techniques_youtube_index_path do |f| %>
+
       <%= render 'shared/error_message', object: f.object %>
         <%= f.hidden_field :source_type %>
+
+      <div class="field py-2 px-4">
+        <%= f.text_field :source_url,
+              autofocus: true,
+              autocomplete: "title",
+              class: "input input-md input-bordered w-full",
+              placeholder: "#{@technique.source_type.humanize}のURL",
+              data: {
+                youtube_preview_target: "sourceUrl",
+                action: "input->youtube-preview#update", # inputがあったら、updateメソッドに投げる
+              }
+        %>
+      </div>
+
+      <div class="field py-2 px-4">
+        <%= f.text_field :video_timestamp,
+              autofocus: true,
+              autocomplete: "title",
+              class: "input input-md input-bordered w-full",
+              placeholder: "再生開始地点(HH:MM:SS or MM:SS or SSの形で入力)",
+              data: {
+                youtube_preview_target: "timestamp",
+                action: "input->youtube-preview#update",
+              }
+        %>
+      </div>
+
       <div class="field py-2 px-4">
         <%= f.text_field :title, autofocus: true, autocomplete: "title", class: "input input-md input-bordered w-full", placeholder: "タイトル" %>
       </div>
-      <div class="field py-2 px-4">
-        <%= f.text_field :source_url, autofocus: true, autocomplete: "title", class: "input input-md input-bordered w-full", placeholder: "#{@technique.source_type.humanize}のURL" %>
-      </div>
-      <div class="field py-2 px-4">
-        <%= f.text_field :video_timestamp, autofocus: true, autocomplete: "title", class: "input input-md input-bordered w-full", placeholder: "再生開始地点(HH:MM:SS or MM:SS or SSの形で入力)" %>
-      </div>
+
       <div class="field py-2 px-4">
         <%= f.text_field :category_names, autofocus: true, autocomplete: "title", class: "input input-md input-bordered w-full", placeholder: "カテゴリー名（コンマ（,）区切りで複数入力可能）" %>
       </div>

--- a/app/views/techniques/youtube/new.html.erb
+++ b/app/views/techniques/youtube/new.html.erb
@@ -74,7 +74,13 @@
 
 
   <%# ======右側：ブラウザのモックアップ====== %>
-  <div class="w-full lg:w-1/2 xl:w-2/3 mt-10 lg:mt-0">
+  <div class="w-full lg:w-1/2 xl:w-2/3 mt-10 ml-4 lg:mt-0 lg:ml-4 lg:mr-4">
+
+    <div class="items-center m-4">
+      <h2 class="text-center text-xl font-bold tracking-tight text-gray-900">プレビュー画面</h2>
+      <h2 class="text-center text-lg tracking-tight text-gray-900">（こちらで実際に作成されるページを事前確認できます）</h2>
+    </div>
+
     <div class="mockup-browser border-base-300 border">
       <div class="mockup-browser-toolbar">
         <div class="input border-base-300 border">https://v-tactics.com</div>
@@ -89,7 +95,7 @@
         </div>
 
         <div data-youtube-preview-target="previewTitle" class="mt-4 text-xl font-bold line-clamp-1">タイトル</div>
-        <div data-youtube-preview-target="previewOriginalTitle" class="mt-2 text-md line-clamp-1">元動画：（ここに動画タイトルが表示されます）</div>
+        <div data-youtube-preview-target="previewOriginalTitle" class="mt-2 text-md line-clamp-1">元動画：<%= @movie_title %></div>
 
         <div data-youtube-preview-target="previewCategories" class="mt-4 mb-4 flex flex-wrap gap-2">
         </div>
@@ -109,12 +115,8 @@
           <div class="btn">編集</div>
           <div class="btn">削除</div>
 
-          <!-- マイフォルダに保存 ボタン -->
-          <div class="tooltip" data-tip="もうすぐ実装予定！">
-            <a href="#" class="btn btn-primary">マイフォルダに保存</a>
-          </div>
+          <div class="btn btn-primary">マイフォルダに保存</div>
 
-          <%# お気に入りボタン %>
           <div class="btn btn-soft btn-warning">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-star" viewBox="0 0 16 16">
               <path d="M2.866 14.85c-.078.444.36.791.746.593l4.39-2.256 4.389 2.256c.386.198.824-.149.746-.592l-.83-4.73 3.522-3.356c.33-.314.16-.888-.282-.95l-4.898-.696L8.465.792a.513.513 0 0 0-.927 0L5.354 5.12l-4.898.696c-.441.062-.612.636-.283.95l3.523 3.356-.83 4.73zm4.905-2.767-3.686 1.894.694-3.957a.56.56 0 0 0-.163-.505L1.71 6.745l4.052-.576a.53.53 0 0 0 .393-.288L8 2.223l1.847 3.658a.53.53 0 0 0 .393.288l4.052.575-2.906 2.77a.56.56 0 0 0-.163.506l.694 3.957-3.686-1.894a.5.5 0 0 0-.461 0z"/>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,4 +37,5 @@ Rails.application.routes.draw do
       delete "unfollow", to: "follows#destroy"
     end
   end
+  get "/youtube/title", to: "youtube_api#title"
 end


### PR DESCRIPTION
## Close
closes #149 #150 

## 変更前
![image](https://github.com/user-attachments/assets/442d901f-adc1-4aa3-8b55-f3c76a4f6079)

## 変更後
![image](https://github.com/user-attachments/assets/cfe9a708-837b-4e91-b3f0-4d680e272550)

## やること

- [x] youtubeのURLを入れるとプレビュー画面が出るようにする
- [x] 投稿前に、投稿されたときにどのような形になるかユーザーにわかりやすくページを表示する

## できるようになること（ユーザー視点）

- 投稿された後のページがイメージしやすくなる
- 投稿する前に動画プレビューを見れることで、動画指定秒数（タイムスタンプ）を調整しやすくなる

## 今後やりたいこと

- 編集画面でも実装する。

## 参考

URLからYoutubeのIDを抜き取る正規表現
https://follmy.com/ruby-youtube-embeded/

