### PR TITLE
Update category index

### DIFF
--- a/app/controllers/techniques_controller.rb
+++ b/app/controllers/techniques_controller.rb
@@ -9,7 +9,11 @@ class TechniquesController < ApplicationController
     @swiper_techniques = Technique.includes(:user).order(created_at: :desc).limit(5)
     @youtube_techniques = @techniques.where(source_type: "youtube").limit(6)
     @twitter_techniques = @techniques.where(source_type: "twitter").limit(6)
-    @categories = Category.all
+
+    @beginner_categories  = Category.beginner
+    @agents_categories = Category.agents
+    @maps_categories = Category.maps
+    @others_categories = Category.others
   end
 
   def search

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -40,7 +40,7 @@ class Category < ApplicationRecord
     "サンセット"
   ]
 
-  BEGINNER = ["初心者"]
+  BEGINNER = [ "初心者" ]
 
   has_many :technique_categories, dependent: :destroy
   has_many :techniques, through: :technique_categories
@@ -53,5 +53,4 @@ class Category < ApplicationRecord
   scope :maps, -> { where(name: MAPS) }
   scope :beginner, -> { where(name: BEGINNER) }
   scope :others, -> { where.not(name: AGENTS + MAPS + BEGINNER) }
-
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,8 +1,57 @@
 class Category < ApplicationRecord
+  AGENTS = [
+    "アストラ",
+    "ブリーチ",
+    "ブリムストーン",
+    "チェンバー",
+    "クローヴ",
+    "サイファー",
+    "デッドロック",
+    "フェイド",
+    "ゲッコー",
+    "ハーバー",
+    "アイソ",
+    "ジェット",
+    "KAY/O",
+    "キルジョイ",
+    "ネオン",
+    "オーメン",
+    "フェニックス",
+    "レイズ",
+    "レイナ",
+    "セージ",
+    "スカイ",
+    "ソーヴァ",
+    "ヴァイパー",
+    "ヨル"
+  ]
+
+  MAPS = [
+    "アビス",
+    "アセント",
+    "バインド",
+    "ブリーズ",
+    "フラクチャー",
+    "ヘイヴン",
+    "アイスボックス",
+    "ロータス",
+    "パール",
+    "スプリット",
+    "サンセット"
+  ]
+
+  BEGINNER = ["初心者"]
+
   has_many :technique_categories, dependent: :destroy
   has_many :techniques, through: :technique_categories
   has_many :follows, dependent: :destroy
   has_many :followers, through: :follows, source: :user
 
   validates :name, presence: true
+
+  scope :agents, -> { where(name: AGENTS) }
+  scope :maps, -> { where(name: MAPS) }
+  scope :beginner, -> { where(name: BEGINNER) }
+  scope :others, -> { where.not(name: AGENTS + MAPS + BEGINNER) }
+
 end

--- a/app/views/techniques/index.html.erb
+++ b/app/views/techniques/index.html.erb
@@ -48,6 +48,11 @@
         Categories
       </h3>
     </div>
+    <div class="flex w-full flex-col lg:flex-row">
+      <div class="card bg-base-300 rounded-box grid h-32 grow place-items-center">content</div>
+      <div class="divider lg:divider-horizontal">OR</div>
+      <div class="card bg-base-300 rounded-box grid h-32 grow place-items-center">content</div>
+    </div>
     <div class="relative mx-auto max-w-7xl">
       <div class="mt-12 flex flex-wrap justify-center gap-4">
         <% @categories.each do |category| %>
@@ -90,7 +95,7 @@
         <% if @youtube_techniques.present? %>
           <% @youtube_techniques.each do |technique| %>
             <div class="mb-12 flex flex-col overflow-hidden">
-              <%= link_to techniques_youtube_path(technique) do %>
+              <%= link_to techniques_youtube_path(technique), data: { turbo_frame: "_top" } do %>
 
                 <%# youtube %>
                 <div class="shrink-0">
@@ -110,7 +115,7 @@
 
                     <div class="mt-2 mb-2">
                       <% technique.categories.each do |category| %>
-                        <%= link_to category.name, category_path(category), class: "badge badge-info" %>
+                        <%= link_to category.name, category_path(category), data: { turbo_frame: "_top" }, class: "badge badge-info" %>
                       <% end %>
                     </div>
 
@@ -130,7 +135,7 @@
                 </div>
 
                 <div class="flex justify-center items-center gap-2 mt-2">
-                  <%= link_to "詳細画面へ", techniques_youtube_path(technique), class: "btn btn-primary" %>
+                  <%= link_to "詳細画面へ", techniques_youtube_path(technique), data: { turbo_frame: "_top" }, class: "btn btn-primary" %>
                   <div id="<%= dom_id(technique, :favorite_button) %>">
                     <%= render "techniques/favorite_button", technique: technique %>
                   </div>

--- a/app/views/techniques/index.html.erb
+++ b/app/views/techniques/index.html.erb
@@ -48,17 +48,52 @@
         Categories
       </h3>
     </div>
-    <div class="flex w-full flex-col lg:flex-row">
-      <div class="card bg-base-300 rounded-box grid h-32 grow place-items-center">content</div>
-      <div class="divider lg:divider-horizontal">OR</div>
-      <div class="card bg-base-300 rounded-box grid h-32 grow place-items-center">content</div>
-    </div>
-    <div class="relative mx-auto max-w-7xl">
-      <div class="mt-12 flex flex-wrap justify-center gap-4">
-        <% @categories.each do |category| %>
-          <%= link_to category.name, category_path(category), class: "btn btn-sm btn-info" %>
+
+    <div class="mt-8 flex w-full flex-col lg:flex-row">
+      <%# 初心者 %>
+      <div class="card rounded-box grid min-h-32 grow place-items-center p-4">
+      <div class="text-center font-bold">初心者はまずココから！</div>
+        <% @beginner_categories.each do |category| %>
+          <%= link_to category.name, category_path(category), class: "btn btn-sm btn-success" %>
         <% end %>
       </div>
+
+      <div class="divider lg:divider-horizontal"></div>
+
+      <%# エージェント %>
+      <div class="card rounded-box grid min-h-32 grow place-items-center p-4">
+      <div class="text-center font-bold">エージェント</div>
+        <div class="flex flex-wrap justify-center gap-2">
+          <% @agents_categories.each do |category| %>
+            <%= link_to category.name, category_path(category), class: "btn btn-sm btn-info" %>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="divider lg:divider-horizontal"></div>
+
+      <%# マップ %>
+      <div class="card rounded-box grid min-h-32 grow place-items-center p-4">
+      <div class="text-center font-bold">マップ</div>
+        <div class="flex flex-wrap justify-center gap-2">
+          <% @maps_categories.each do |category| %>
+            <%= link_to category.name, category_path(category), class: "btn btn-sm btn-warning" %>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="divider lg:divider-horizontal"></div>
+
+      <%# その他 %>
+      <div class="card rounded-box grid min-h-32 grow place-items-center p-4">
+      <div class="text-center font-bold">その他のカテゴリー</div>
+        <div class="flex flex-wrap justify-center gap-2">
+          <% @others_categories.each do |category| %>
+            <%= link_to category.name, category_path(category), class: "btn btn-sm" %>
+          <% end %>
+        </div>
+      </div>
+
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Close
close #158 

## 実装前
<img width="1920" height="934" alt="image" src="https://github.com/user-attachments/assets/74d78e93-8f0f-4a52-b815-0bf58b174ec4" />

## 実装後
<img width="1920" height="934" alt="image" src="https://github.com/user-attachments/assets/ee78cea9-f52d-464e-87aa-2a416e6d169b" />

## やること

- [x] 初心者向けのコンテンツが作成できる場所を作る
- [x] エージェントとマップを色分けして表示してわかりやすく

## できるようになること（ユーザー視点）

- すぐ調べられる（たどり着きたいテクニックにすぐたどり着ける手がかりがカテゴリーにある）

## 今後やりたいこと

- カテゴリーページにソートを実装（→ #189 としてissue切り）

## 参考
- turbo-framesで「content missing」になった時、`data: { turbo_frame: "_top" }`を書く。
- https://zenn.dev/shita1112/books/cat-hotwire-turbo/viewer/turbo-frames
- モデルに定数を定義し、使う方法
- https://qiita.com/mokio/items/255eae3b03369d27b0ed
