### PR TITLE
Update twitter form

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,5 +10,8 @@ application.register("hello", HelloController)
 import ThemeController from "./theme_controller"
 application.register("theme", ThemeController)
 
+import TwitterPreviewController from "./twitter_preview_controller"
+application.register("twitter-preview", TwitterPreviewController)
+
 import YoutubePreviewController from "./youtube_preview_controller"
 application.register("youtube-preview", YoutubePreviewController)

--- a/app/javascript/controllers/twitter_preview_controller.js
+++ b/app/javascript/controllers/twitter_preview_controller.js
@@ -1,0 +1,72 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="twitter-preview"
+export default class extends Controller {
+
+  // HTMLの要素（ターゲット）をココで指定する
+  static targets = [ "sourceUrl", "titleInput", "categoryInput",
+                    "preview", "previewTitle", "previewCategories"]
+
+  connect() {
+    this.update()
+  }
+
+  update() {
+    this.#updatePost()
+    this.#updateSelfTitle()
+    this.#updateCategories()
+  }
+
+  #updatePost() {
+    const url = this.sourceUrlTarget.value;
+
+    const postId = url.split('/').pop().split('?')[0];
+
+    if (postId && /^[0-9]+$/.test(postId)) {
+      const blockquote = document.createElement('blockquote')
+      blockquote.classList.add('twitter-tweet')
+      const a = document.createElement('a')
+      a.href = `https://twitter.com/user/status/${postId}`
+      blockquote.appendChild(a)
+
+      this.previewTarget.innerHTML = ''
+      this.previewTarget.appendChild(blockquote)
+
+      if (window.twttr) {
+        window.twttr.widgets.load(this.previewTarget)
+      } else {
+        const script = document.createElement('script')
+        script.src = "https://platform.twitter.com/widgets.js"
+        script.async = true
+        script.charset = "utf-8"
+        document.head.appendChild(script)
+      }
+
+    } else {
+      this.previewTarget.innerHTML = `
+        <div class="w-4/5 rounded-lg bg-gray-200 flex items-center justify-center">
+          <span class="text-gray-500">URLが正しいかご確認ください。</span>
+        </div>`
+    }
+
+  }
+
+  #updateSelfTitle() {
+    this.previewTitleTarget.textContent = this.titleInputTarget.value || "左の「オリジナルタイトル」のフォームに入力すると、こちらに好きなタイトルを付けることができます！"
+  }
+
+  #updateCategories() {
+    this.previewCategoriesTarget.innerHTML = ''
+    const categoryNames = this.categoryInputTarget.value
+
+    if (categoryNames) {
+      const categories = categoryNames.split(',').map(name => name.trim()).filter(name => name)
+      categories.forEach(name => {
+        const badge = document.createElement('span')
+        badge.className = 'badge badge-outline badge-primary'
+        badge.textContent = name
+        this.previewCategoriesTarget.appendChild(badge)
+      })
+    }
+  }
+}

--- a/app/views/techniques/twitter/new.html.erb
+++ b/app/views/techniques/twitter/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, t(".title")) %>
 
-<div class="flex min-h-full flex-col lg:flex-row lg:m-6 justify-center md:m-12">
+<div class="flex min-h-full flex-col lg:flex-row lg:m-6 justify-center md:m-12" data-controller="twitter-preview">
 
   <%# ======左側：入力フォーム====== %>
   <div class="w-full lg:w-1/2 xl:w-1/3">
@@ -16,12 +16,41 @@
         <%= f.hidden_field :source_type %>
 
         <div class="field py-2 px-4">
-          <%= f.text_field :source_url, autofocus: true, autocomplete: "title", class: "input input-md input-bordered w-full", placeholder: "XのURL" %>
+          <%= f.text_field :source_url,
+                            autofocus: true,
+                            autocomplete: "title",
+                            class: "input input-md input-bordered w-full",
+                            placeholder: "XのURL",
+                            data: {
+                              twitter_preview_target: "sourceUrl",
+                              action: "input->twitter-preview#update"
+                            }
+          %>
           <span class="label-text-alt ml-2 text-red-600">※必須（Required field）</span>
         </div>
 
         <div class="field py-2 px-4">
-          <%= f.text_field :title, autofocus: true, autocomplete: "title", class: "input input-md input-bordered w-full", placeholder: "タイトル" %>
+          <%= f.text_field :title,
+                            autofocus: true,
+                            autocomplete: "title",
+                            class: "input input-md input-bordered w-full",
+                            placeholder: "オリジナルタイトル（例：ソーヴァ サンセット リコン）",
+                            data: {
+                              twitter_preview_target: "titleInput",
+                              action: "input->twitter-preview#update"
+                            }
+          %>
+        </div>
+
+        <div class="field py-2 px-4">
+          <%= f.text_field :category_names,
+                class: "input input-md input-bordered w-full",
+                placeholder: "カテゴリー名（コンマ（,）区切りで複数入力可能）",
+                data: {
+                  twitter_preview_target: "categoryInput",
+                  action: "input->twitter-preview#update"
+                }
+          %>
         </div>
 
         <div class="actions text-center py-4 px-4">
@@ -49,13 +78,13 @@
 
       <div class="border-base-300 flex flex-col items-center justify-center border-t px-4 py-8 md:px-8">
 
-        <div class="w-4/5 rounded-lg bg-gray-200 flex items-center justify-center">
+        <div data-twitter-preview-target="preview" class="w-4/5 rounded-lg bg-gray-200 flex items-center justify-center">
           <span class="text-gray-500">投稿前に投稿が確認できます</span>
         </div>
 
-        <div class="mt-4 text-xl font-bold line-clamp-1">タイトル</div>
+        <div data-twitter-preview-target="previewTitle" class="mt-4 text-xl font-bold line-clamp-1">タイトル</div>
 
-        <div class="mt-4 mb-4 flex flex-wrap gap-2">
+        <div data-twitter-preview-target="previewCategories" class="mt-4 mb-4 flex flex-wrap gap-2">
         </div>
 
         <%# ボタン系 %>

--- a/app/views/techniques/twitter/new.html.erb
+++ b/app/views/techniques/twitter/new.html.erb
@@ -1,24 +1,93 @@
 <% content_for(:title, t(".title")) %>
-<div class="flex min-h-full flex-col justify-center md:m-12">
-  <div class="sm:mx-auto sm:w-full sm:max-w-sm">
-    <h2 class="mt-10 text-center text-2xl/9 font-bold tracking-tight text-gray-900">テクニック登録</h2>
+
+<div class="flex min-h-full flex-col lg:flex-row lg:m-6 justify-center md:m-12">
+
+  <%# ======左側：入力フォーム====== %>
+  <div class="w-full lg:w-1/2 xl:w-1/3">
+    <div class="sm:mx-auto sm:w-full sm:max-w-sm">
+      <h2 class="mt-10 text-center text-2xl/9 font-bold tracking-tight">Xテクニック登録</h2>
+    </div>
+
+    <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-md">
+
+      <%= form_with model: @technique, url: techniques_twitter_index_path do |f| %>
+
+        <%= render 'shared/error_message', object: f.object %>
+        <%= f.hidden_field :source_type %>
+
+        <div class="field py-2 px-4">
+          <%= f.text_field :source_url, autofocus: true, autocomplete: "title", class: "input input-md input-bordered w-full", placeholder: "XのURL" %>
+          <span class="label-text-alt ml-2 text-red-600">※必須（Required field）</span>
+        </div>
+
+        <div class="field py-2 px-4">
+          <%= f.text_field :title, autofocus: true, autocomplete: "title", class: "input input-md input-bordered w-full", placeholder: "タイトル" %>
+        </div>
+
+        <div class="actions text-center py-4 px-4">
+          <%= f.submit "投稿する！", class: "btn btn-wide" %>
+        </div>
+      <% end %>
+    </div>
+
   </div>
 
-  <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-md">
+  <%# ======右側：ブラウザのモックアップ====== %>
+  <div class="w-full lg:w-1/2 xl:w-2/3 mt-10 ml-4 lg:mt-0 lg:ml-4 lg:mr-4">
 
-    <%= form_with model: @technique, url: techniques_twitter_index_path do |f| %>
-      <%= render 'shared/error_message', object: f.object %>
-        <%= f.hidden_field :source_type %>
-      <div class="field py-2 px-4">
-        <%= f.text_field :title, autofocus: true, autocomplete: "title", class: "input input-md input-bordered w-full", placeholder: "タイトル" %>
-      </div>
-      <div class="field py-2 px-4">
-        <%= f.text_field :source_url, autofocus: true, autocomplete: "title", class: "input input-md input-bordered w-full", placeholder: "XのURL" %>
+    <div class="items-center m-4">
+      <h2 class="text-center text-xl font-bold tracking-tight">プレビュー画面</h2>
+      <h2 class="text-center text-lg tracking-tight">（こちらで実際に作成されるページを事前確認できます）</h2>
+    </div>
+
+    <div class="mockup-browser border-base-300 border">
+      <div class="mockup-browser-toolbar">
+        <div class="input border-base-300 border">https://v-tactics.com</div>
       </div>
 
-      <div class="actions text-center py-4 px-4">
-        <%= f.submit "投稿する！", class: "btn btn-wide" %>
+      <%# モックアップの中身 %>
+
+      <div class="border-base-300 flex flex-col items-center justify-center border-t px-4 py-8 md:px-8">
+
+        <div class="w-4/5 rounded-lg bg-gray-200 flex items-center justify-center">
+          <span class="text-gray-500">投稿前に投稿が確認できます</span>
+        </div>
+
+        <div class="mt-4 text-xl font-bold line-clamp-1">タイトル</div>
+
+        <div class="mt-4 mb-4 flex flex-wrap gap-2">
+        </div>
+
+        <%# ボタン系 %>
+        <div class="mt-2 flex flex-wrap gap-3">
+
+          <div class="btn bg-black text-white">Xへ</div>
+
+          <div class="btn">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-twitter-x" viewBox="0 0 16 16">
+              <path d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865z"/>
+            </svg>
+            で共有する
+          </div>
+
+          <div class="btn">編集</div>
+          <div class="btn">削除</div>
+
+          <div class="btn btn-primary">マイフォルダに保存</div>
+
+          <div class="btn btn-soft btn-warning">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-star" viewBox="0 0 16 16">
+              <path d="M2.866 14.85c-.078.444.36.791.746.593l4.39-2.256 4.389 2.256c.386.198.824-.149.746-.592l-.83-4.73 3.522-3.356c.33-.314.16-.888-.282-.95l-4.898-.696L8.465.792a.513.513 0 0 0-.927 0L5.354 5.12l-4.898.696c-.441.062-.612.636-.283.95l3.523 3.356-.83 4.73zm4.905-2.767-3.686 1.894.694-3.957a.56.56 0 0 0-.163-.505L1.71 6.745l4.052-.576a.53.53 0 0 0 .393-.288L8 2.223l1.847 3.658a.53.53 0 0 0 .393.288l4.052.575-2.906 2.77a.56.56 0 0 0-.163.506l.694 3.957-3.686-1.894a.5.5 0 0 0-.461 0z"/>
+            </svg>
+            <span>お気に入り</span>
+          </div>
+
+        </div>
+
       </div>
-    <% end %>
+
+
+
+    </div>
   </div>
 </div>

--- a/app/views/techniques/youtube/new.html.erb
+++ b/app/views/techniques/youtube/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, t(".title")) %>
 
-<%# 生成した際に指示が書いてあったコントローラーの読み込みをココに追記 %>
+<%# stimulusを生成した際に指示が書いてあったコントローラーの読み込みをココに追記 %>
 <div class="flex min-h-full flex-col lg:flex-row lg:m-6 justify-center md:m-12" data-controller="youtube-preview">
 
   <%# ======左側：入力フォーム====== %>


### PR DESCRIPTION
## Close
close #151 

## 実装前
[![Image from Gyazo](https://i.gyazo.com/3993b9c17ba4f78ebea5856f811ba52a.png)](https://gyazo.com/3993b9c17ba4f78ebea5856f811ba52a)

## 実装後
[![Image from Gyazo](https://i.gyazo.com/864102ec8f7445915bb8a20f5ec2654f.png)](https://gyazo.com/864102ec8f7445915bb8a20f5ec2654f)

## やること
- [x] Twitter用のテクニック登録フォームをYoutubeのフォームと統一（Youtubeのテクニック登録フォームを優先していた）

## できるようになること（ユーザー視点）
- どのように登録されるのかイメージしながら、登録できる。

## 今後やりたいこと
- Xの詳細ページにカテゴリが反映されていない（→ #195 にてissue切り）
- debounce実装（→ #196 にてissue切り）

## 参考
前のYoutube投稿フォームを作った時のプルリクエスト参照
https://github.com/kohei-financier/V-TACTICS/pull/174
