### PR TITLE
update: gem pgのアップデート

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "rails", "~> 7.2.2", ">= 7.2.2.1"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
 # Use postgresql as the database for Active Record
-gem "pg", "~> 1.1"
+gem "pg", "~> 1.6"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
 # Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,7 +288,13 @@ GEM
     parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
-    pg (1.5.9)
+    pg (1.6.1)
+    pg (1.6.1-aarch64-linux)
+    pg (1.6.1-aarch64-linux-musl)
+    pg (1.6.1-arm64-darwin)
+    pg (1.6.1-x86_64-darwin)
+    pg (1.6.1-x86_64-linux)
+    pg (1.6.1-x86_64-linux-musl)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -542,7 +548,7 @@ DEPENDENCIES
   omniauth
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
-  pg (~> 1.1)
+  pg (~> 1.6)
   pry-rails
   puma (>= 5.0)
   pundit

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -1232,6 +1232,6 @@
         "branches": {}
       }
     },
-    "timestamp": 1754310879
+    "timestamp": 1754708816
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -13,7 +13,7 @@
       <img src="./assets/0.13.1/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2025-08-04T21:34:39+09:00">2025-08-04T21:34:39+09:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2025-08-09T12:06:56+09:00">2025-08-09T12:06:56+09:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">


### PR DESCRIPTION
## やったこと
- [x] `pg` gem を `1.5.9` から `1.6.1` にアップデート

## なぜ実行したか
- dependbot対応のため、ローカル環境で確認

## `pg` gemとは
- PostgreSQLを使う時に使うgem（リサーチするとPostgreSQLとの接続に使っている様子）

## ローカルでの確認事項
- [x] Rspecテストが通過するか
- [x] railsコンソールでデータが取得できるか
- [x] CRUDができるか 

## 参考
RubyでPostgreSQLを使うために知っておきたい最低限のこと（pgを使います）
https://study-infra.com/ruby-postgresql-pg-begginer/
