### PR TITLE
update: gem pumaのアップデート

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,7 +307,7 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
-    puma (6.6.0)
+    puma (6.6.1)
       nio4r (~> 2.0)
     pundit (2.5.0)
       activesupport (>= 3.0.0)

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -1232,6 +1232,6 @@
         "branches": {}
       }
     },
-    "timestamp": 1754708816
+    "timestamp": 1754711302
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -13,7 +13,7 @@
       <img src="./assets/0.13.1/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2025-08-09T12:06:56+09:00">2025-08-09T12:06:56+09:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2025-08-09T12:48:22+09:00">2025-08-09T12:48:22+09:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">


### PR DESCRIPTION
## やったこと
- [x] `puma` gem を `6.6.0` から `6.6.1` にアップデート

## なぜ実行したか
- dependbot対応のため、ローカル環境で確認

## `puma` gemとは
- PumaはWebサーバーの一種。アプリケーションサーバとして主に動作し、Rackの役割を補助してHTTPリクエストを高速かつ同時処理的に行うことを可能にする。

rack・・・下記参考記事を読むと、HTTPリクエストを直接アプリケーションでは消化ができないため、アプリケーションサーバーとアプリケーション（コードが書かれたファイル）の間に立って、リクエストを消化→レスポンスを返す仲介役を担っている。

## 上記から、ローカルでの確認事項
- [x] 正常にページ接続できるか
- [x] CRUDができるか 
- [x] Rspecが通るか

## 参考記事
Rails：Pumaは何者？
https://kichintodaisuke.wordpress.com/2020/04/29/rails%EF%BC%9Apuma%E3%81%AF%E4%BD%95%E8%80%85%EF%BC%9F/
3StepでRailsとRackに入門する
https://zenn.dev/shogo_k0323/articles/aa7e42a1b5916a

