### PR TITLE
Update ransack gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -365,7 +365,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.0)
-    ransack (4.2.1)
+    ransack (4.3.0)
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
       i18n

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -1232,6 +1232,6 @@
         "branches": {}
       }
     },
-    "timestamp": 1754816760
+    "timestamp": 1754826447
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -13,7 +13,7 @@
       <img src="./assets/0.13.1/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2025-08-10T18:06:00+09:00">2025-08-10T18:06:00+09:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2025-08-10T20:47:27+09:00">2025-08-10T20:47:27+09:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">


### PR DESCRIPTION
## やったこと
- [x] `ransack`gemを`4.2.1`から`4.3.0`にアップデート

## なぜ実行したか
- dependbot対応のため、ローカル環境で確認

## `ransack` gemとは
- Ransackは検索機能を簡単に実装できるgem

## 上記から、ローカルでの確認事項
- [x] 正常にページ接続できるか
- [x] Rspecが通るか
- [x] 検索機能を使えるか
