### PR TITLE
fix: 利用規約とプライバシーポリシーの文字色変更

### DIFF
--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -5,10 +5,10 @@
 
   <div class="divider"></div>
 
-  <section class="mb-8 text-gray-700 leading-relaxed">
+  <section class="mb-8 leading-relaxed">
     <h2 class="text-2xl font-semibold mb-4 border-b pb-2">1. お客様から取得する情報</h2>
     <p class="mb-3 leading-relaxed">当社は、お客様から以下の情報を取得します。</p>
-    <ul class="list-disc list-inside ml-4 text-gray-700">
+    <ul class="list-disc list-inside ml-4">
         <li class="mb-1">ユーザー名</li>
         <li class="mb-1">メールアドレス</li>
         <li class="mb-1">外部サービスでお客様が利用するIDおよび、外部サービスのプライバシー設定によりお客様が開示を認めた情報</li>
@@ -20,10 +20,10 @@
     </ul>
   </section>
 
-  <section class="mb-8 text-gray-700 leading-relaxed">
+  <section class="mb-8 leading-relaxed">
     <h2 class="text-2xl font-semibold mb-4 border-b pb-2">2. お客様の情報を利用する目的</h2>
     <p class="mb-3 leading-relaxed">当社は、お客様から取得した情報を以下の目的で利用します。</p>
-    <ul class="list-disc list-inside ml-4 text-gray-700">
+    <ul class="list-disc list-inside ml-4">
         <li class="mb-1">サービス登録手続の受付、本人確認および認証処理のため</li>
         <li class="mb-1">当社サービスにおけるお客様の利用履歴の管理のため</li>
         <li class="mb-1">当社サービスの利便性向上や機能改善に役立てるため</li>
@@ -36,15 +36,15 @@
     </ul>
   </section>
 
-  <section class="mb-8 text-gray-700 leading-relaxed">
+  <section class="mb-8 leading-relaxed">
     <h2 class="text-2xl font-semibold mb-4 border-b pb-2">3. 安全管理のために講じた措置</h2>
     <p class="leading-relaxed">当社は、お客様の情報を保護するため、アクセス制限、通信の暗号化（SSL）など、適切な安全管理措置を講じています。詳細については、法令に基づき合理的な範囲で個別にご案内いたします。</p>
   </section>
 
-  <section class="mb-8 text-gray-700 leading-relaxed">
+  <section class="mb-8 leading-relaxed">
     <h2 class="text-2xl font-semibold mb-4 border-b pb-2">4. 第三者提供</h2>
     <p class="leading-relaxed">当社は、お客様の個人データ（個人情報保護法第16条第3項）を、以下の場合を除き、あらかじめお客様の同意を得ることなく第三者（日本国外の者を含む）に提供することはありません。</p>
-    <ul class="list-disc list-inside ml-4 text-gray-700">
+    <ul class="list-disc list-inside ml-4">
         <li class="mb-1">個人データの取扱いを外部に委託する場合</li>
         <li class="mb-1">当社や当社サービスが買収された場合</li>
         <li class="mb-1">事業パートナーとの共同利用（共同利用の内容は別途公表します）</li>
@@ -52,7 +52,7 @@
     </ul>
   </section>
 
-  <section class="mb-8 text-gray-700 leading-relaxed">
+  <section class="mb-8 leading-relaxed">
     <h2 class="text-2xl font-semibold mb-4 border-b pb-2">5. アクセス解析ツールの利用</h2>
     <p class="mb-3 leading-relaxed">当社は、アクセス解析のために「Googleアナリティクス」を利用しています。GoogleアナリティクスはCookieを使用し、匿名のトラフィックデータを収集します。個人を特定するものではありません。</p>
     <p class="mb-3 leading-relaxed">Cookieを無効にすることで、情報の収集を拒否することが可能です。詳しくは、お使いのブラウザの設定をご確認ください。</p>
@@ -60,12 +60,12 @@
     <a href="https://marketingplatform.google.com/about/analytics/terms/jp/" class="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">https://marketingplatform.google.com/about/analytics/terms/jp/</a></p>
   </section>
 
-  <section class="mb-8 text-gray-700 leading-relaxed">
+  <section class="mb-8 leading-relaxed">
     <h2 class="text-2xl font-semibold mb-4 border-b pb-2">6. プライバシーポリシーの変更</h2>
     <p class="leading-relaxed">当社は、必要に応じて本プライバシーポリシーを変更することがあります。その場合、変更後の施行時期および内容を、当社ウェブサイト等を通じて適切に通知または公表します。</p>
   </section>
 
-  <section class="mb-8 text-gray-700 leading-relaxed">
+  <section class="mb-8 leading-relaxed">
     <h2 class="text-2xl font-semibold mb-4 border-b pb-2">7. お問い合わせ</h2>
     <p class="mb-3 leading-relaxed">お客様の情報の開示、訂正、利用停止、削除をご希望される場合は、お問い合わせフォームよりご連絡ください。</p>
     <p class="mb-3 leading-relaxed">ご本人確認のため、運転免許証等の提示をお願いする場合があります。なお、開示請求については、開示の有無にかかわらず、1件あたり1,000円（税込）の事務手数料を申し受けます。</p>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -4,7 +4,7 @@
   <div class="text-center">最終更新日：2025年6月10日</div>
 
   <div class="divider"></div>
-  <section class="mb-8 text-gray-700 leading-relaxed">
+  <section class="mb-8 leading-relaxed">
     この利用規約（以下，「<span class="font-semibold">本規約</span>」といいます。）は，<span class="font-semibold">「V-TACTICS」</span>（以下，「<span class="font-semibold">当社</span>」といいます。）がこのウェブサイト上で提供するサービス（以下，「<span class="font-semibold">本サービス</span>」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下，「<span class="font-semibold">ユーザー</span>」といいます。）には，本規約に従って，本サービスをご利用いただきます。
   </section>
 
@@ -19,7 +19,7 @@
       <h2 class="text-2xl font-semibold mb-4 border-b pb-2">第2条（利用登録）</h2>
       <p class="mb-3 leading-relaxed">本サービスにおいては，登録希望者が本規約に同意の上，当社の定める方法によって利用登録を申請し，当社がこれを承認することによって，利用登録が完了するものとします。</p>
       <p class="mb-3 leading-relaxed">当社は，利用登録の申請者に以下の事由があると判断した場合，利用登録の申請を承認しないことがあり，その理由については一切の開示義務を負わないものとします。</p>
-      <ul class="list-disc list-inside ml-4 text-gray-700">
+      <ul class="list-disc list-inside ml-4">
           <li class="mb-1">利用登録の申請に際して虚偽の事項を届け出た場合</li>
           <li class="mb-1">本規約に違反したことがある者からの申請である場合</li>
           <li>その他，当社が利用登録を相当でないと判断した場合</li>
@@ -42,7 +42,7 @@
   <section class="mb-8">
       <h2 class="text-2xl font-semibold mb-4 border-b pb-2">第5条（禁止事項）</h2>
       <p class="mb-3 leading-relaxed">ユーザーは，本サービスの利用にあたり，以下の行為をしてはなりません。</p>
-      <ul class="list-disc list-inside ml-4 text-gray-700">
+      <ul class="list-disc list-inside ml-4">
           <li class="mb-1">法令または公序良俗に違反する行為</li>
           <li class="mb-1">犯罪行為に関連する行為</li>
           <li class="mb-1">本サービスの内容等，本サービスに含まれる著作権，商標権ほか知的財産権を侵害する行為</li>
@@ -64,7 +64,7 @@
   <section class="mb-8">
       <h2 class="text-2xl font-semibold mb-4 border-b pb-2">第6条（本サービスの提供の停止等）</h2>
       <p class="mb-3 leading-relaxed">当社は，以下のいずれかの事由があると判断した場合，ユーザーに事前に通知することなく本サービスの全部または一部の提供を停止または中断することができるものとします。</p>
-      <ul class="list-disc list-inside ml-4 text-gray-700">
+      <ul class="list-disc list-inside ml-4">
           <li class="mb-1">本サービスにかかるコンピュータシステムの保守点検または更新を行う場合</li>
           <li class="mb-1">地震，落雷，火災，停電または天災などの不可抗力により，本サービスの提供が困難となった場合</li>
           <li class="mb-1">コンピュータまたは通信回線等が事故により停止した場合</li>
@@ -76,7 +76,7 @@
   <section class="mb-8">
       <h2 class="text-2xl font-semibold mb-4 border-b pb-2">第7条（利用制限および登録抹消）</h2>
       <p class="mb-3 leading-relaxed">当社は，ユーザーが以下のいずれかに該当する場合には，事前の通知なく，ユーザーに対して，本サービスの全部もしくは一部の利用を制限し，またはユーザーとしての登録を抹消することができるものとします。</p>
-      <ul class="list-disc list-inside ml-4 text-gray-700">
+      <ul class="list-disc list-inside ml-4">
           <li class="mb-1">本規約のいずれかの条項に違反した場合</li>
           <li class="mb-1">登録事項に虚偽の事実があることが判明した場合</li>
           <li class="mb-1">料金等の支払債務の不履行があった場合</li>
@@ -108,7 +108,7 @@
   <section class="mb-8">
       <h2 class="text-2xl font-semibold mb-4 border-b pb-2">第11条（利用規約の変更）</h2>
       <p class="mb-3 leading-relaxed">当社は以下の場合には、ユーザーの個別の同意を要せず、本規約を変更することができるものとします。</p>
-      <ul class="list-disc list-inside ml-4 text-gray-700">
+      <ul class="list-disc list-inside ml-4">
           <li class="mb-1">本規約の変更がユーザーの一般の利益に適合するとき。</li>
           <li>本規約の変更が本サービス利用契約の目的に反せず、かつ、変更の必要性、変更後の内容の相当性その他の変更に係る事情に照らして合理的なものであるとき。</li>
       </ul>


### PR DESCRIPTION
## 起こっていた事象
- ダークモードで利用規約とプライバシーポリシーに暗めの色がかかっていて見えなくなっていた。
<img width="3360" height="1808" alt="image" src="https://github.com/user-attachments/assets/70124eda-8892-4762-aaa0-cea93a27b831" />


## やること
- [x] ダークモード時に利用規約とプライバシーポリシーの文字色変更
<img width="3360" height="1808" alt="image" src="https://github.com/user-attachments/assets/28ff626c-5462-48dc-bdcb-6588aebdde04" />


