### PR TITLE
change: postgreアップデートによるpostgreバージョンの固定化

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres
+    image: postgres:17
     restart: always
     environment:
       TZ: Asia/Tokyo


### PR DESCRIPTION
## やること

- [x] 下記を解決する（docker compose upでdbが立ち上がらない）
```
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/var/lib/docker/volumes/MYDATA/_data" to rootfs at "/var/lib/postgresql/data": change mount propagation through procfd: open o_path procfd: open /var/lib/docker/rootfs/overlayfs/012345678901234567890123456789/var/lib/postgresql/data: no such file or directory: unknown
```

## 原因
- postgresの18がリリースされたことにより、postgresバージョンを指定していない場合、最新版の「18」として認識されてしまう。

## 解決方法
compose.ymlのpostgresバージョンを「17」に指定。
